### PR TITLE
Stack component with recipes ( flexbox )

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { lightThemeClass } from "./styles/theme/lightTheme.css";
 import SprinklesBox from "./components/SprinklesBox";
 import { SprinklesButton } from "./components/SprinklesButton";
 import { RecipesButton } from "./components/RecipesButton";
+import { Stack } from "./components/Stack";
 
 const THEMES = {
   dark: darkThemeClass,
@@ -30,12 +31,27 @@ function App() {
       <SprinklesBox p={"2xl"} m={["sm", "lg", "xl", "2xl"]}>
         <h1>Vite + React + Vanilla-Extract</h1>
       </SprinklesBox>
-      <SprinklesButton size={"sm"} variant={"primary"}>
-        Drop a Like for sprinkles
-      </SprinklesButton>
-      <RecipesButton size={"sm"} variant={"primary"}>
-        Drop a Like for recipes
-      </RecipesButton>
+      <Stack
+        direction={"column"}
+        spacing={"sm"}
+        justify={"space-between"}
+        align={"center"}
+      >
+        <h1>This is a column stack with a row stack inside for buttons</h1>
+        <Stack
+          direction={"row"}
+          spacing={"md"}
+          justify={"space-between"}
+          align={"center"}
+        >
+          <SprinklesButton size={"sm"} variant={"primary"}>
+            Drop a Like for sprinkles
+          </SprinklesButton>
+          <RecipesButton size={"sm"} variant={"primary"}>
+            Drop a Like for recipes
+          </RecipesButton>
+        </Stack>
+      </Stack>
     </div>
   );
 }

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -10,9 +10,22 @@ import {
 export type StackProps = PropsWithChildren<
   StackParentVariants & StackChildVariants
 >;
-export const Stack = ({ children, ...props }: StackProps) => {
-  const stackParentClass = stackParent(props);
-  const stackChildClass = stackChild(props);
+export const Stack = ({
+  children,
+  spacing,
+  justify,
+  align,
+  direction,
+}: StackProps) => {
+  const stackParentClass = stackParent({
+    direction,
+    align,
+    justify,
+  });
+  const stackChildClass = stackChild({
+    direction,
+    spacing,
+  });
   const childrenArray = React.Children.toArray(children);
   return (
     <div className={`stack-parent ${stackElementClass}  ${stackParentClass}`}>

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,0 +1,26 @@
+import React, { PropsWithChildren } from "react";
+import {
+  stackChild,
+  StackChildVariants,
+  stackElementClass,
+  stackParent,
+  StackParentVariants,
+} from "./stack.css";
+
+export type StackProps = PropsWithChildren<
+  StackParentVariants & StackChildVariants
+>;
+export const Stack = ({ children, ...props }: StackProps) => {
+  const stackParentClass = stackParent(props);
+  const stackChildClass = stackChild(props);
+  const childrenArray = React.Children.toArray(children);
+  return (
+    <div className={`stack-parent ${stackElementClass}  ${stackParentClass}`}>
+      {childrenArray.map((child, index) => (
+        <div className={`stack-child ${stackChildClass}`} key={index}>
+          {child}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/stack.css.ts
+++ b/src/components/stack.css.ts
@@ -1,0 +1,142 @@
+import { globalStyle, style, StyleRule } from "@vanilla-extract/css";
+import { spacing as spacingRules, vars } from "../styles/theme/baseTheme.css";
+import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
+import { Globals, Property } from "csstype";
+
+const FLEX_DIRECTIONS = [
+  "row",
+  "row-reverse",
+  "column",
+  "column-reverse",
+] as readonly Exclude<Property.FlexDirection, Globals>[];
+
+const ALIGN_RULES = [`flex-start`, `center`, `flex-end`, `baseline`] as const;
+const JUSTIFY_RULES = [
+  `flex-start`,
+  `center`,
+  `flex-end`,
+  `space-between`,
+] as const;
+
+type MarginRule =
+  | Property.MarginTop
+  | Property.MarginBottom
+  | Property.MarginLeft
+  | Property.MarginRight;
+
+export type SpacingValue = keyof typeof vars.spacing;
+
+const RULE_BY_DIRECTION: Record<typeof FLEX_DIRECTIONS[number], MarginRule> = {
+  row: "marginLeft",
+  column: "marginTop",
+  "row-reverse": "marginRight",
+  "column-reverse": "marginBottom",
+} as const;
+
+const SPACINGS_KEYS = Object.keys(spacingRules) as Array<
+  keyof typeof spacingRules
+>;
+
+export const stackElementClass = style({});
+
+export const stackParent = recipe({
+  base: { display: "flex" },
+  variants: {
+    direction: {
+      row: {
+        flexDirection: "row",
+      },
+      "row-reverse": {
+        flexDirection: "row-reverse",
+      },
+      column: {
+        flexDirection: "column",
+      },
+      "column-reverse": {
+        flexDirection: "column-reverse",
+      },
+    },
+    align: ALIGN_RULES.reduce<Record<typeof ALIGN_RULES[number], StyleRule>>(
+      (acc, key) =>
+        Object.assign(acc, {
+          [key]: {
+            alignItems: key,
+          },
+        }),
+      {} as Record<typeof ALIGN_RULES[number], StyleRule>
+    ),
+    justify: JUSTIFY_RULES.reduce<
+      Record<typeof JUSTIFY_RULES[number], StyleRule>
+    >(
+      (acc, key) =>
+        Object.assign(acc, {
+          [key]: {
+            justifyContent: key,
+          },
+        }),
+      {} as Record<typeof JUSTIFY_RULES[number], StyleRule>
+    ),
+    spacing: SPACINGS_KEYS.reduce<
+      Record<typeof SPACINGS_KEYS[number], StyleRule>
+    >(
+      (acc, key) => Object.assign(acc, { [key]: {} }),
+      {} as Record<typeof SPACINGS_KEYS[number], StyleRule>
+    ),
+  },
+});
+export const stackChild = recipe({
+  base: style({
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    marginRight: 0,
+  }),
+  variants: {
+    direction: {
+      row: {},
+      "row-reverse": {},
+      column: {},
+      "column-reverse": {},
+    },
+    align: ALIGN_RULES.reduce<Record<typeof ALIGN_RULES[number], StyleRule>>(
+      (acc, key) =>
+        Object.assign(acc, {
+          [key]: {},
+        }),
+      {} as Record<typeof ALIGN_RULES[number], StyleRule>
+    ),
+    justify: JUSTIFY_RULES.reduce<
+      Record<typeof JUSTIFY_RULES[number], StyleRule>
+    >(
+      (acc, key) =>
+        Object.assign(acc, {
+          [key]: {},
+        }),
+      {} as Record<typeof JUSTIFY_RULES[number], StyleRule>
+    ),
+    spacing: SPACINGS_KEYS.reduce<
+      Record<typeof SPACINGS_KEYS[number], StyleRule>
+    >(
+      (acc, key) => Object.assign(acc, { [key]: {} }),
+      {} as Record<typeof SPACINGS_KEYS[number], StyleRule>
+    ),
+  },
+  compoundVariants: FLEX_DIRECTIONS.flatMap((direction) => {
+    return SPACINGS_KEYS.map((spacing) => ({
+      variants: {
+        direction,
+        spacing,
+      },
+      style: style({
+        selectors: {
+          [`${stackElementClass} > & + &`]: {
+            [RULE_BY_DIRECTION[direction]]: spacingRules[spacing],
+          },
+        },
+      }),
+    }));
+  }),
+});
+
+export type StackParentVariants = RecipeVariants<typeof stackParent>;
+export type StackChildVariants = RecipeVariants<typeof stackChild>;

--- a/src/components/stack.css.ts
+++ b/src/components/stack.css.ts
@@ -43,29 +43,29 @@ const SPACINGS_KEYS = Object.keys(spacingRules) as Array<
 
 export const stackElementClass = style({});
 
-const mapVariants = <VariantName extends Readonly<string>>(
-  variantNames: Readonly<VariantName[]>,
-  mapFn?: (variantName: VariantName) => StyleRule
-): Record<VariantName, StyleRule> =>
-  variantNames.reduce<Record<VariantName, StyleRule>>(
-    (acc, variantName) =>
+const mapVariantValues = <V extends Readonly<string>>(
+  variantValues: Readonly<V[]>,
+  mapFn?: (value: V) => StyleRule
+): Record<V, StyleRule> =>
+  variantValues.reduce<Record<V, StyleRule>>(
+    (acc, value) =>
       Object.assign(acc, {
-        [variantName]: mapFn?.(variantName) ?? {},
+        [value]: mapFn?.(value) ?? {},
       }),
-    {} as Record<VariantName, StyleRule>
+    {} as Record<V, StyleRule>
   );
 
 export const stackParent = recipe({
   base: { display: "flex" },
   variants: {
-    direction: mapVariants(FLEX_DIRECTIONS, (variantName) => ({
-      flexDirection: variantName,
+    direction: mapVariantValues(FLEX_DIRECTIONS, (variantValue) => ({
+      flexDirection: variantValue,
     })),
-    align: mapVariants(ALIGN_RULES, (variantName) => ({
-      alignItems: variantName,
+    align: mapVariantValues(ALIGN_RULES, (variantValue) => ({
+      alignItems: variantValue,
     })),
-    justify: mapVariants(JUSTIFY_RULES, (variantName) => ({
-      justifyContent: variantName,
+    justify: mapVariantValues(JUSTIFY_RULES, (variantValue) => ({
+      justifyContent: variantValue,
     })),
   },
 });
@@ -77,8 +77,8 @@ export const stackChild = recipe({
     marginRight: 0,
   }),
   variants: {
-    direction: mapVariants(FLEX_DIRECTIONS),
-    spacing: mapVariants(SPACINGS_KEYS),
+    direction: mapVariantValues(FLEX_DIRECTIONS),
+    spacing: mapVariantValues(SPACINGS_KEYS),
   },
   compoundVariants: FLEX_DIRECTIONS.flatMap((direction) => {
     return SPACINGS_KEYS.map((spacing) => ({

--- a/src/components/stack.css.ts
+++ b/src/components/stack.css.ts
@@ -46,7 +46,7 @@ export const stackElementClass = style({});
 const mapVariants = <VariantName extends Readonly<string>>(
   variantNames: Readonly<VariantName[]>,
   mapFn?: (variantName: VariantName) => StyleRule
-): Record<VariantName[][number], StyleRule> =>
+): Record<VariantName, StyleRule> =>
   variantNames.reduce<Record<VariantName, StyleRule>>(
     (acc, variantName) =>
       Object.assign(acc, {

--- a/src/components/stack.css.ts
+++ b/src/components/stack.css.ts
@@ -1,30 +1,34 @@
-import { globalStyle, style, StyleRule } from "@vanilla-extract/css";
+import { style, StyleRule } from "@vanilla-extract/css";
 import { spacing as spacingRules, vars } from "../styles/theme/baseTheme.css";
 import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
-import { Globals, Property } from "csstype";
+import { Property } from "csstype";
+import React from "react";
 
-const FLEX_DIRECTIONS = [
-  "row",
-  "row-reverse",
-  "column",
-  "column-reverse",
-] as readonly Exclude<Property.FlexDirection, Globals>[];
+type CssPropertyValues<
+  T extends keyof React.CSSProperties,
+  N extends React.CSSProperties[T]
+> = readonly Extract<React.CSSProperties[T], N>[];
 
-const ALIGN_RULES = [`flex-start`, `center`, `flex-end`, `baseline`] as const;
-const JUSTIFY_RULES = [
-  `flex-start`,
-  `center`,
-  `flex-end`,
-  `space-between`,
-] as const;
+const FLEX_DIRECTIONS: CssPropertyValues<
+  "flexDirection",
+  "row" | "row-reverse" | "column" | "column-reverse"
+> = ["row", "row-reverse", "column", "column-reverse"] as const;
+
+const ALIGN_RULES: CssPropertyValues<
+  "alignItems",
+  `flex-start` | `center` | `flex-end` | `baseline`
+> = [`flex-start`, `center`, `flex-end`, `baseline`] as const;
+
+const JUSTIFY_RULES: CssPropertyValues<
+  "justifyContent",
+  `flex-start` | `center` | `flex-end` | `space-between`
+> = [`flex-start`, `center`, `flex-end`, `space-between`] as const;
 
 type MarginRule =
   | Property.MarginTop
   | Property.MarginBottom
   | Property.MarginLeft
   | Property.MarginRight;
-
-export type SpacingValue = keyof typeof vars.spacing;
 
 const RULE_BY_DIRECTION: Record<typeof FLEX_DIRECTIONS[number], MarginRule> = {
   row: "marginLeft",
@@ -39,49 +43,30 @@ const SPACINGS_KEYS = Object.keys(spacingRules) as Array<
 
 export const stackElementClass = style({});
 
+const mapVariants = <VariantName extends Readonly<string>>(
+  variantNames: Readonly<VariantName[]>,
+  mapFn?: (variantName: VariantName) => StyleRule
+): Record<VariantName[][number], StyleRule> =>
+  variantNames.reduce<Record<VariantName, StyleRule>>(
+    (acc, variantName) =>
+      Object.assign(acc, {
+        [variantName]: mapFn?.(variantName) ?? {},
+      }),
+    {} as Record<VariantName, StyleRule>
+  );
+
 export const stackParent = recipe({
   base: { display: "flex" },
   variants: {
-    direction: {
-      row: {
-        flexDirection: "row",
-      },
-      "row-reverse": {
-        flexDirection: "row-reverse",
-      },
-      column: {
-        flexDirection: "column",
-      },
-      "column-reverse": {
-        flexDirection: "column-reverse",
-      },
-    },
-    align: ALIGN_RULES.reduce<Record<typeof ALIGN_RULES[number], StyleRule>>(
-      (acc, key) =>
-        Object.assign(acc, {
-          [key]: {
-            alignItems: key,
-          },
-        }),
-      {} as Record<typeof ALIGN_RULES[number], StyleRule>
-    ),
-    justify: JUSTIFY_RULES.reduce<
-      Record<typeof JUSTIFY_RULES[number], StyleRule>
-    >(
-      (acc, key) =>
-        Object.assign(acc, {
-          [key]: {
-            justifyContent: key,
-          },
-        }),
-      {} as Record<typeof JUSTIFY_RULES[number], StyleRule>
-    ),
-    spacing: SPACINGS_KEYS.reduce<
-      Record<typeof SPACINGS_KEYS[number], StyleRule>
-    >(
-      (acc, key) => Object.assign(acc, { [key]: {} }),
-      {} as Record<typeof SPACINGS_KEYS[number], StyleRule>
-    ),
+    direction: mapVariants(FLEX_DIRECTIONS, (variantName) => ({
+      flexDirection: variantName,
+    })),
+    align: mapVariants(ALIGN_RULES, (variantName) => ({
+      alignItems: variantName,
+    })),
+    justify: mapVariants(JUSTIFY_RULES, (variantName) => ({
+      justifyContent: variantName,
+    })),
   },
 });
 export const stackChild = recipe({
@@ -92,34 +77,8 @@ export const stackChild = recipe({
     marginRight: 0,
   }),
   variants: {
-    direction: {
-      row: {},
-      "row-reverse": {},
-      column: {},
-      "column-reverse": {},
-    },
-    align: ALIGN_RULES.reduce<Record<typeof ALIGN_RULES[number], StyleRule>>(
-      (acc, key) =>
-        Object.assign(acc, {
-          [key]: {},
-        }),
-      {} as Record<typeof ALIGN_RULES[number], StyleRule>
-    ),
-    justify: JUSTIFY_RULES.reduce<
-      Record<typeof JUSTIFY_RULES[number], StyleRule>
-    >(
-      (acc, key) =>
-        Object.assign(acc, {
-          [key]: {},
-        }),
-      {} as Record<typeof JUSTIFY_RULES[number], StyleRule>
-    ),
-    spacing: SPACINGS_KEYS.reduce<
-      Record<typeof SPACINGS_KEYS[number], StyleRule>
-    >(
-      (acc, key) => Object.assign(acc, { [key]: {} }),
-      {} as Record<typeof SPACINGS_KEYS[number], StyleRule>
-    ),
+    direction: mapVariants(FLEX_DIRECTIONS),
+    spacing: mapVariants(SPACINGS_KEYS),
   },
   compoundVariants: FLEX_DIRECTIONS.flatMap((direction) => {
     return SPACINGS_KEYS.map((spacing) => ({
@@ -130,7 +89,7 @@ export const stackChild = recipe({
       style: style({
         selectors: {
           [`${stackElementClass} > & + &`]: {
-            [RULE_BY_DIRECTION[direction]]: spacingRules[spacing],
+            [RULE_BY_DIRECTION[direction]]: vars.spacing[spacing],
           },
         },
       }),

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -24,29 +24,31 @@ function transformBreakpoints<Output>(input: Record<string, any>) {
   return responsiveConditions;
 }
 
+export const responsiveSupportedProps = {
+  position: [`relative`],
+  display: [`none`, `block`, `inline`, `inline-block`, `flex`],
+  alignItems: [`flex-start`, `center`, `flex-end`, `baseline`],
+  justifyContent: [`flex-start`, `center`, `flex-end`, `space-between`],
+  flexDirection: [`row`, `row-reverse`, `column`, `column-reverse`],
+  flexWrap: [`wrap`, `nowrap`],
+  padding: spacing,
+  paddingTop: spacing,
+  paddingBottom: spacing,
+  paddingLeft: spacing,
+  paddingRight: spacing,
+  margin: spacing,
+  marginTop: spacing,
+  marginBottom: spacing,
+  marginLeft: spacing,
+  marginRight: spacing,
+} as const;
+
 const responsiveProperties = defineProperties({
   conditions:
     transformBreakpoints<Record<keyof typeof BREAKPOINTS, {}>>(BREAKPOINTS),
   responsiveArray: ["xs", "sm", "md", "lg", "xl", "2xl"] as const,
   defaultCondition: "xs" as const,
-  properties: {
-    position: [`relative`],
-    display: [`none`, `block`, `inline`, `inline-block`, `flex`],
-    alignItems: [`flex-start`, `center`, `flex-end`, `baseline`],
-    justifyContent: [`flex-start`, `center`, `flex-end`, `space-between`],
-    flexDirection: [`row`, `row-reverse`, `column`, `column-reverse`],
-    flexWrap: [`wrap`, `nowrap`],
-    padding: spacing,
-    paddingTop: spacing,
-    paddingBottom: spacing,
-    paddingLeft: spacing,
-    paddingRight: spacing,
-    margin: spacing,
-    marginTop: spacing,
-    marginBottom: spacing,
-    marginLeft: spacing,
-    marginRight: spacing,
-  },
+  properties: responsiveSupportedProps,
   // this composes rules and must be ordered!
   // "px" and "py" are after "p" so they can override it
   shorthands: {
@@ -82,4 +84,9 @@ export type SprinklesSpaceProps = Pick<
   | "m"
   | "mx"
   | "my"
+>;
+
+export type SprinklesFlexboxProps = Pick<
+  Sprinkles,
+  "justifyContent" | "alignItems" | "flexDirection" | "flexWrap"
 >;

--- a/src/styles/theme/baseTheme.css.ts
+++ b/src/styles/theme/baseTheme.css.ts
@@ -8,22 +8,22 @@ export const BREAKPOINTS = {
   md: 768,
   lg: 1024,
   xl: 1280,
-  "2xl": 1680
+  "2xl": 1680,
 } as const;
 
 const borderStyle = {
   default: "1px solid",
-  interactive: "2px solid"
+  interactive: "2px solid",
 };
 
 const radii = {
   xs: `0.25 rem`,
   sm: `0.5 rem`,
   md: `0.75 rem`,
-  lg: `1 rem`
+  lg: `1 rem`,
 };
 
-const spacing = {
+export const spacing = {
   "6xs": `2px`,
   "5xs": `4px`,
   "4xs": `8px`,
@@ -34,8 +34,8 @@ const spacing = {
   md: `40px`,
   lg: `48px`,
   xl: `56px`,
-  "2xl": `64px`
-};
+  "2xl": `64px`,
+} as const;
 
 const sizing = {
   "2xs": `16`,
@@ -44,33 +44,33 @@ const sizing = {
   md: `40`,
   lg: `48`,
   xl: `56`,
-  "2xl": `64`
+  "2xl": `64`,
 };
 
 export const baseTheme = {
   font: {
-    body: SYSTEM_FONT
+    body: SYSTEM_FONT,
   },
   borderStyle,
   radii,
   spacing,
-  sizing
+  sizing,
 };
 
 export const vars = createThemeContract({
   colors: {
     background: {
       primary: ``,
-      secondary: ``
+      secondary: ``,
     },
     text: {
       primary: ``,
       secondary: ``,
-      disable: ``
-    }
+      disable: ``,
+    },
   },
   font: {
-    body: ``
+    body: ``,
   },
   spacing: {
     "6xs": ``,
@@ -83,7 +83,7 @@ export const vars = createThemeContract({
     md: ``,
     lg: ``,
     xl: ``,
-    "2xl": ``
+    "2xl": ``,
   },
   sizing: {
     "2xs": ``,
@@ -92,16 +92,16 @@ export const vars = createThemeContract({
     md: ``,
     lg: ``,
     xl: ``,
-    "2xl": ``
+    "2xl": ``,
   },
   radii: {
     xs: ``,
     sm: ``,
     md: ``,
-    lg: ``
+    lg: ``,
   },
   borderStyle: {
     default: ``,
-    interactive: ``
-  }
+    interactive: ``,
+  },
 });


### PR DESCRIPTION

**WHAT IS IN THIS PR**

This brings my own attempt to understand the techniques that can be used to create a Stack component with vanilla extract.

### why first an attempt with recipes

First off this is a non responsive implementation since responsiveness would have made this way out of scope (IMHO).

What we are mostly interested at is 
- direction ( flexDirection)
- justify ( justifyContent )
- align ( alignItems ) 
- spacing ( margin between child elements ) 

Direction, Justify, align are not an issue since i can directly pass them to the Stack parent element. 

Recipe was chosen over sprinkles because i was immediately caught by the [compound variants]() capability

```tsx
// Applied when multiple variants are set at once
  compoundVariants: [
    {
      variants: {
        color: 'neutral',
        size: 'large'
      },
      style: {
        background: 'ghostwhite'
      }
    }
```

This fits totally since our stack will apply spacing direction ( margin top, right, bottom, left ) and size based on a combination of direction and spacing size values.

#### This is why i started with recipes.

What i "almost died on" is the spacing for children.

### spacing children issue

#### what does a stack do

This is the fun part since our current stack relies on the capability to select child from parent.
```tsx
{
    // parent rules
    display: "flex",
    alignItems: align,
    justifyContent: justify,
    flexDirection: direction,
    // margin will be zero and have a size only based on direction ( 
"row" | "column" | "row-reverse" | "column-reverse")
    "& > * + *": { // here is the issue, WE CAN'T DO THIS 
      marginTop: childrenMarginTop,
      marginBottom: childrenMarginBottom,
      marginLeft: childrenMarginLeft,
      marginRight: childrenMarginRight,
    },
  }
  
  
  // later in component
   <StackWrapper
        {...rest}
        childrenMarginTop={computedDirection === "column" ? spacing : 0}
        childrenMarginBottom={
          computedDirection === "column-reverse" ? spacing : 0
        }
        childrenMarginLeft={computedDirection === "row" ? spacing : 0}
        childrenMarginRight={computedDirection === "row-reverse" ? spacing : 0}
        align={align}
        justify={justify}
        direction={computedDirection}
        ref={ref}
      >
        {children}
      </StackWrapper>
```

This is not something you cannot do in vanilla extract without being hacky.

#### Issue

  "& > * + *" selector is not accepted, documentation explains why [here](https://vanilla-extract.style/documentation/styling/#complex-selectors).
You cannot select anything else that is not the current element you're styling.

#### Solutions ideas

The doc explains what can be done.
I have to reference the parent class (in our case the stack wrapper class) in the child style.
```tsx
// **** this is from the doc  *** //

import { style } from '@vanilla-extract/css';

// Invalid example:
export const child = style({});
export const parent = style({
  selectors: {
    // ❌ ERROR: Targetting `child` from `parent`
    [`& ${child}`]: {...}
  }
});

// Valid example:
export const parent = style({});
export const child = style({
  selectors: {
    [`${parent} &`]: {...}
  }
});
```
Am i supposed to :
- render children with render props applying classes? Does not look practical
- create an higher order component that decorates a component with a className? same thing different pattern

What the heck should i do?  

After losing a discrete amount of time i checked out vanilla extract repo to see what they do. 
I must have been missing something and please tell me you do not add some markup.....
Ops they do.

#### The Solution

I don't like one bit but that's the way it is.
If you cannot select an element the only way you have is place a child class which references the parent.
And if you can't apply a class to every child what do you do? 
Add an additional "div" around each child 🪦 
This is the stack component from [vanilla extract repo ](https://github.com/vanilla-extract-css/vanilla-extract/blob/master/site/src/system/Stack/Stack.tsx).
Keep in mind their stack is only vertical.
Here's an extract:
```tsx
 const stackItems = Children.toArray(children);
return (
    <Box display="flex" flexDirection="column" alignItems={alignItems}>
      {stackItems.map((item, index) => (
        <Box
          key={index}
          paddingBottom={index !== stackItems.length - 1 ? space : undefined}
        >
          {item}
        </Box>
      ))}
    </Box>
  );
```
And there you have it. 
Hacky but hey, maybe they'll figure something out in the future.

#### now that we know how let's create a child style let's do it

Child style can be created with the before mentioned compoundVariants capability.
You can loop on all directions and for each direction loop all spacing possibilities and create a style for it.

```tsx
//child Recipe receives direction and spacing variants but just uses them for compound styles
 compoundVariants: FLEX_DIRECTIONS.flatMap((direction) => {
    return SPACINGS_KEYS.map((spacing) => ({
      variants: {
        direction,
        spacing,
      },
      style: style({
        selectors: {
          //select parent from child 🎲 
          [`${stackElementClass} > & + &`]: {
            [RULE_BY_DIRECTION[direction]]: vars.spacing[spacing],
          },
        },
      }),
    }));
```

#### a note about mapVariantValues

This is just an util to apply variant values, it is probably overkill but was done to explore Css types that could be useful in these cases.
You can apply variant entries from an array of property names and be able to create each style with a map function.
```tsx
// this
type CssPropertyValues<
  T extends keyof React.CSSProperties,
  N extends React.CSSProperties[T]
> = readonly Extract<React.CSSProperties[T], N>[];

const FLEX_DIRECTIONS: CssPropertyValues<
  "flexDirection",
  "row" | "row-reverse" | "column" | "column-reverse"
> = ["row", "row-reverse", "column", "column-reverse"] as const;

mapVariantValues(FLEX_DIRECTIONS, (variantValue) => ({
    flexDirection: variantValue,
  }))

// translates to these
 {
    row: {
      flexDirection: "row",
    },
    "row-reverse": {
      flexDirection: "row-reverse",
    },
    column: {
      flexDirection: "column",
    },
    "column-reverse": {
      flexDirection: "column-reverse",
    },
},
```

#### an idea to avoid child classes

CompoundVariants is very cool.

Not being able to target a child sucks as hell, placing an extra div sound hacky.
A justification i tried to give myself is: 
"It is what Bootstrap has done in ages before with float and then with flexbox, place a div around your elements to produce columns and each column had a gutter ( padding )"
Well, they explored what native Css+html can do and chose their way.
Here the library(vanilla extract) is forcing us to pick a way.

So what i asked myself is.
is there a way to avoid this through css.
Display grid should make it but this is for another PR...

 


  