### PR TITLE
refactor: adopt stack spacing through gap rules instead of additional markup

### DIFF
--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,39 +1,7 @@
 import React, { PropsWithChildren } from "react";
-import {
-  stackChild,
-  StackChildVariants,
-  stackElementClass,
-  stackParent,
-  StackParentVariants,
-} from "./stack.css";
+import { stackParent, StackVariants } from "./stack.css";
 
-export type StackProps = PropsWithChildren<
-  StackParentVariants & StackChildVariants
->;
-export const Stack = ({
-  children,
-  spacing,
-  justify,
-  align,
-  direction,
-}: StackProps) => {
-  const stackParentClass = stackParent({
-    direction,
-    align,
-    justify,
-  });
-  const stackChildClass = stackChild({
-    direction,
-    spacing,
-  });
-  const childrenArray = React.Children.toArray(children);
-  return (
-    <div className={`stack-parent ${stackElementClass}  ${stackParentClass}`}>
-      {childrenArray.map((child, index) => (
-        <div className={`stack-child ${stackChildClass}`} key={index}>
-          {child}
-        </div>
-      ))}
-    </div>
-  );
-};
+export type StackProps = PropsWithChildren<StackVariants>;
+export const Stack = ({ children, ...props }: StackProps) => (
+  <div className={`stack-parent ${stackParent(props)}`}>{children}</div>
+);

--- a/src/components/stack.css.ts
+++ b/src/components/stack.css.ts
@@ -1,7 +1,6 @@
-import { style, StyleRule } from "@vanilla-extract/css";
+import { StyleRule } from "@vanilla-extract/css";
 import { spacing as spacingRules, vars } from "../styles/theme/baseTheme.css";
 import { recipe, RecipeVariants } from "@vanilla-extract/recipes";
-import { Property } from "csstype";
 import React from "react";
 
 type CssPropertyValues<
@@ -24,24 +23,9 @@ const JUSTIFY_RULES: CssPropertyValues<
   `flex-start` | `center` | `flex-end` | `space-between`
 > = [`flex-start`, `center`, `flex-end`, `space-between`] as const;
 
-type MarginRule =
-  | Property.MarginTop
-  | Property.MarginBottom
-  | Property.MarginLeft
-  | Property.MarginRight;
-
-const RULE_BY_DIRECTION: Record<typeof FLEX_DIRECTIONS[number], MarginRule> = {
-  row: "marginLeft",
-  column: "marginTop",
-  "row-reverse": "marginRight",
-  "column-reverse": "marginBottom",
-} as const;
-
 const SPACINGS_KEYS = Object.keys(spacingRules) as Array<
   keyof typeof spacingRules
 >;
-
-export const stackElementClass = style({});
 
 const mapVariantValues = <V extends Readonly<string>>(
   variantValues: Readonly<V[]>,
@@ -67,17 +51,6 @@ export const stackParent = recipe({
     justify: mapVariantValues(JUSTIFY_RULES, (variantValue) => ({
       justifyContent: variantValue,
     })),
-  },
-});
-export const stackChild = recipe({
-  base: style({
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 0,
-    marginRight: 0,
-  }),
-  variants: {
-    direction: mapVariantValues(FLEX_DIRECTIONS),
     spacing: mapVariantValues(SPACINGS_KEYS),
   },
   compoundVariants: FLEX_DIRECTIONS.flatMap((direction) => {
@@ -86,16 +59,12 @@ export const stackChild = recipe({
         direction,
         spacing,
       },
-      style: style({
-        selectors: {
-          [`${stackElementClass} > & + &`]: {
-            [RULE_BY_DIRECTION[direction]]: vars.spacing[spacing],
-          },
-        },
-      }),
+      style: {
+        columnGap: direction.includes("row") ? vars.spacing[spacing] : 0,
+        rowGap: direction.includes("column") ? vars.spacing[spacing] : 0,
+      },
     }));
   }),
 });
 
-export type StackParentVariants = RecipeVariants<typeof stackParent>;
-export type StackChildVariants = RecipeVariants<typeof stackChild>;
+export type StackVariants = RecipeVariants<typeof stackParent>;


### PR DESCRIPTION
This adopts an alternative solution to the additional markup solution applied in [vanilla extract repository](https://github.com/vanilla-extract-css/vanilla-extract/blob/master/site/src/system/Stack/Stack.tsx).

### gap rules

This  gap proposal was found at [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap).

Markup + Css wise 
- you can apply a css gap between elements with a rule on the parent level
- markup stays as it is intended, wapper + plain children
- margin on the child element stays untouched
- no classes to apply other than the stack wrapper

TS logic:
- no need to manage x axis spacing direction ( left | right ) but just x axis ( row | column )
- no need to have child logic

#### [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap#browser_compatibility)

It looks usable pretty much everywhere so good.


